### PR TITLE
Added support for running behind a reverse proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,7 @@ app.use(function (err, req,res,next){
 
 
 var server = http.Server(app);
+skip_ssl = (skip_ssl !== undefined && skip_ssl == true);
 if (!skip_ssl && app_id.match(/^https:\/\/localhost:/)) {
 	var options = {
 		key: fs.readFileSync('server.key'),

--- a/index.js
+++ b/index.js
@@ -36,11 +36,12 @@ logger.setLevel(logLevel);
 var port = (process.env.VCAP_APP_PORT || process.env.PORT || 3000);
 var host = (process.env.VCAP_APP_HOST || '0.0.0.0');
 var mongo_url = (process.env.MONGO_URL || 'mongodb://localhost:27017/assistant');
+logger.debug("Mongo url: ", mongo_url);
 
 var mqtt_url = (process.env.MQTT_URL || 'mqtt://localhost:1883');
 var mqtt_user = (process.env.MQTT_USER || undefined);
 var mqtt_password = (process.env.MQTT_PASSWORD || undefined);
-console.log(mqtt_url);
+logger.debug("MQTT url: ", mqtt_url);
 
 mqtt_url = url.parse(mqtt_url);
 
@@ -71,7 +72,6 @@ if (process.env.VCAP_APPLICATION) {
 	app_id = 'https://' + app_uri;
 }
 
-console.log(mongo_url);
 mongoose.Promise = global.Promise;
 var mongoose_options = {
 	server: {

--- a/index.js
+++ b/index.js
@@ -241,6 +241,7 @@ if ((skip_ssl !== true) && app_id.match(/^https:\/\/localhost:/)) {
 		cert: fs.readFileSync('server.crt')
 	};
 	server = https.createServer(options, app);
+	console.log('Notice: Using repo provided SSL key and certificate.')
 } 
 
 

--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ app.use(function (err, req,res,next){
 	res.send("File Not Found");
 });
 
-var server = http.Server(app);
+var server = http.createServer(app);
 
 // Determine if we have to use the repo provided SSL certificate.
 var skip_ssl = (process.env.SKIP_SSL || undefined);

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ logger.setLevel(logLevel);
 
 var port = (process.env.VCAP_APP_PORT || process.env.PORT || 3000);
 var host = (process.env.VCAP_APP_HOST || '0.0.0.0');
+var skip_ssl = (process.env.SKIP_SSL || false);
+
 var mongo_url = (process.env.MONGO_URL || 'mongodb://localhost:27017/assistant');
 logger.debug("Mongo url: ", mongo_url);
 
@@ -233,7 +235,7 @@ app.use(function (err, req,res,next){
 
 
 var server = http.Server(app);
-if (app_id.match(/^https:\/\/localhost:/)) {
+if ((skip_ssl !== true) && app_id.match(/^https:\/\/localhost:/)) {
 	var options = {
 		key: fs.readFileSync('server.key'),
 		cert: fs.readFileSync('server.crt')

--- a/index.js
+++ b/index.js
@@ -70,11 +70,6 @@ if (process.env.VCAP_APPLICATION) {
 	app_id = 'https://' + app_uri;
 }
 
-// Determine if we have to use the repo provided SSL certificate.
-var skip_ssl = (process.env.SKIP_SSL || undefined);
-skip_ssl = (skip_ssl !== undefined && skip_ssl == true);
-skip_ssl = (!skip_ssl && app_id.match(/^https:\/\/localhost:/));
-
 mongoose.Promise = global.Promise;
 var mongoose_options = {
 	server: {
@@ -235,6 +230,11 @@ app.use(function (err, req,res,next){
 });
 
 var server = http.Server(app);
+
+// Determine if we have to use the repo provided SSL certificate.
+var skip_ssl = (process.env.SKIP_SSL || undefined);
+skip_ssl = (skip_ssl !== undefined && skip_ssl == true);
+skip_ssl = (!skip_ssl && app_id.match(/^https:\/\/localhost:/));
 if (!skip_ssl) {
 	var options = {
 		key: fs.readFileSync('server.key'),

--- a/index.js
+++ b/index.js
@@ -246,5 +246,5 @@ if (!skip_ssl) {
 server.listen(port, host, function(){
 	console.log('App listening on %s:%d!', host, port);
 	console.log('App_ID: %s', app_id);
-	console.log('Using HTTPS?: ', skip_ssl ? 'false' : 'true');
+	console.log('Using HTTPS?:', skip_ssl ? 'false' : 'true');
 });

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ logger.setLevel(logLevel);
 
 var port = (process.env.VCAP_APP_PORT || process.env.PORT || 3000);
 var host = (process.env.VCAP_APP_HOST || '0.0.0.0');
-var skip_ssl = (process.env.SKIP_SSL || false);
+var skip_ssl = (process.env.SKIP_SSL || undefined);
 
 var mongo_url = (process.env.MONGO_URL || 'mongodb://localhost:27017/assistant');
 logger.debug("Mongo url: ", mongo_url);
@@ -235,7 +235,7 @@ app.use(function (err, req,res,next){
 
 
 var server = http.Server(app);
-if ((skip_ssl !== true) && app_id.match(/^https:\/\/localhost:/)) {
+if (!skip_ssl && app_id.match(/^https:\/\/localhost:/)) {
 	var options = {
 		key: fs.readFileSync('server.key'),
 		cert: fs.readFileSync('server.crt')

--- a/models/device.js
+++ b/models/device.js
@@ -30,9 +30,7 @@ var Schema = mongoose.Schema;
 
 var Device = new Schema({
 	username: String,
-	id: {type: Number, get: function(value){
-		return value.toString();
-	}},
+	id: Number,
 	name: {
 		name: String,
 		nicknames: [String]


### PR DESCRIPTION
Locally i have my docker setup all running behind Traefik; however the `app_id` still matched `https://localhost:3000` which made the code use the locally provided certificates. By introducing an environment variable called `process.env.skip_ssl` you can now skip the loading of these certificates, but it is only skipped when the env variable is both set and set to `true`.

In the same merge request i moved 2 `console.log()` statemtens to `logger.debug()` to clean up the console output a bit (i know, should have done this in a seperate pull request)